### PR TITLE
Hardcode "ignore" method

### DIFF
--- a/babel/messages/extract.py
+++ b/babel/messages/extract.py
@@ -236,9 +236,12 @@ def extract_from_file(method, filename, keywords=DEFAULT_KEYWORDS,
     :returns: list of tuples of the form ``(lineno, message, comments, context)``
     :rtype: list[tuple[int, str|tuple[str], list[str], str|None]
     """
-    with open(filename, 'rb') as fileobj:
-        return list(extract(method, fileobj, keywords, comment_tags, options,
-                            strip_comment_tags))
+    if method == 'ignore':
+        return []
+    else:
+        with open(filename, 'rb') as fileobj:
+            return list(extract(method, fileobj, keywords, comment_tags,
+                                options, strip_comment_tags))
 
 
 def extract(method, fileobj, keywords=DEFAULT_KEYWORDS, comment_tags=(),


### PR DESCRIPTION
The "ignore" method still forces the opening of a file, but this is pointless.

Some editors (emacs) create symbolic links to use as synchronization locks. Those links have an extension that matches the opened file, but the links themselves do not point to an existing file, thus causing Babel to attempt to open a file that does not exist.

For example, on my machine, I have a file opened in my editor (project/i18n.py) resulting in the following link being created:

```
.#i18n.py -> sebleblanc@host.11171:1575144024
```

Babel will catch this file with the default `**.py` mapping, so I created a mapping with the pattern `[ignore: **/.*]` thinking it would ignore all files beginning with a dot, but instead, it pointlessly attempts to open such files and pass them through a "no-op" processor. Since it does not discriminate against links, this results in a FileNotFoundError, aborting extraction of all messages.

This fix skips opening of a file altogether when using the method "ignore" in the mapping file, by short-circuiting the `extract_from_file` function when the method matches "ignore".